### PR TITLE
Extend PrintActionSimpleType

### DIFF
--- a/event-logging.xsd
+++ b/event-logging.xsd
@@ -3098,9 +3098,13 @@
         <xs:restriction base="xs:string">
             <xs:enumeration value="CreateJob"/>
             <xs:enumeration value="CancelJob"/>
+            <xs:enumeration value="PauseJob"/>
+            <xs:enumeration value="ResumeJob"/>
             <xs:enumeration value="StartPrint"/>
             <xs:enumeration value="FinishPrint"/>
             <xs:enumeration value="CancelPrint"/>
+            <xs:enumeration value="FailedPrint"/>
+            <xs:enumeration value="Other"/>
         </xs:restriction>
     </xs:simpleType>
     <xs:simpleType name="PrintSettingsOrientationSimpleType">


### PR DESCRIPTION
#6 Refers:
This PR extends the print action enumerations found in the `PrintActionSimpleType` simple Type.

We add
`PauseJob`, `ResumeJob`, `FailedPrint` and `Other`