### PR TITLE
Add Data element to PrintSettings element

### DIFF
--- a/event-logging.xsd
+++ b/event-logging.xsd
@@ -651,6 +651,14 @@
                                                                             <xs:documentation>True if fonts are to be used on the printing device. Using device fonts reduces the size of the print job as no font information needs to be supplied to the printer. However, using device fonts will result in different output on different printers. Most print jobs will not use device fonts so this defaults to false and can therefore be omitted if device fonts are not being used.</xs:documentation>
                                                                         </xs:annotation>
                                                                     </xs:element>
+                                                                    <xs:element name="Data"
+                                                                        type="evt:DataComplexType"
+                                                                        minOccurs="0"
+                                                                        maxOccurs="unbounded">
+                                                                        <xs:annotation>
+                                                                            <xs:documentation>Any other event data that does not fit into a schema element but may be useful for the purpose of audit.</xs:documentation>
+                                                                        </xs:annotation>
+                                                                    </xs:element>
                                                                 </xs:sequence>
                                                             </xs:complexType>
                                                         </xs:element>


### PR DESCRIPTION
This relates to issue #16 
This change allows for an arbitrary number of `PrintSettings` by adding them as `Data` elements. For example, additional settings such as

- Number of Copies
- Duplex printing

can be held in the `Data` elements