### PR TITLE
Correct schema VersionSimpleType enumeration restriction to match the…

### DIFF
--- a/event-logging.xsd
+++ b/event-logging.xsd
@@ -3196,7 +3196,7 @@
         </xs:annotation>
         <xs:restriction base="xs:string">
             <xs:pattern value="[0-9]+(\.[0-9]+)*"/>
-            <xs:enumeration value="3.0.0"/>
+            <xs:enumeration value="3.1.0"/>
         </xs:restriction>
     </xs:simpleType>
     <xs:simpleType name="VirtualSessionSessionStateSimpleType">


### PR DESCRIPTION
Relates to #18 

The Schema has a self check enumeration restriction. This was not updated with the new release of the schema.