### PR TITLE
Add Version attribute to Event fragments

### DIFF
--- a/event-logging.xsd
+++ b/event-logging.xsd
@@ -85,6 +85,11 @@
                 </xs:annotation>
               </xs:element>
             </xs:sequence>
+            <xs:attribute name="Version" type="evt:VersionSimpleType" use="optional">
+              <xs:annotation>
+                <xs:documentation>The version of the schema that this event conforms to. This is useful for standalone Event fragments that are not wrapped in an Events element.</xs:documentation>
+              </xs:annotation>
+            </xs:attribute>
           </xs:complexType>
         </xs:element>
       </xs:sequence>


### PR DESCRIPTION
Fixes #102.

Adds an optional `Version` attribute to individual `Event` elements using the existing `VersionSimpleType`, so standalone fragments can declare their schema version without changing existing wrapped `Events` documents.

## Validation

- `./gradlew check --no-daemon` passed under the repository-required Adoptium JDK 8, including schema-version validation, compilation and tests.
- `xmllint` accepts both an existing unversioned event and the same event with `Version="4.1.0"`.
- An unsupported Event version is rejected by the existing `VersionSimpleType` enumeration.
