### PR TITLE
Add Update permission attribute

### DIFF
--- a/event-logging.xsd
+++ b/event-logging.xsd
@@ -3601,6 +3601,7 @@
       <xs:enumeration value="Owner"/>
       <xs:enumeration value="Read"/>
       <xs:enumeration value="Use"/>
+      <xs:enumeration value="Update"/>
       <xs:enumeration value="Write"/>
     </xs:restriction>
   </xs:simpleType>

--- a/unreleased_changes/20260911_190500_000__70.md
+++ b/unreleased_changes/20260911_190500_000__70.md
@@ -1,0 +1,1 @@
+* Issue **#70** : Add Update to PermissionAttributeSimpleType.


### PR DESCRIPTION
Fixes #70.

Complete the requested `PermissionAttributeSimpleType` expansion by adding the remaining `Update` value. `Create`, `Delete` and `Use` are already present on current master from #76.

Validation:
- Java 8 build generated and validated the full, client, safe, documentation, identity and test schema variants.
- All example XML validation passed with `xmllint`.
- `Update` is present in the generated full, client and safe schemas.
- `git diff --check` passed.

The repository's `diffAgainstLatest` task was excluded because its shell script currently fails independently with `error_exit: command not found`; all schema generation, tests and XML validation completed successfully.
